### PR TITLE
remove examples from make test 

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -69,7 +69,6 @@ function ( make_exe target src )
     add_target_info       ( ${target} )
     target_link_libraries ( ${target} PRIVATE pthread )
     message ( "Example executable to create: ${target}" )
-    add_test ( NAME ${target} COMMAND ${target} )
 endfunction()
 
 foreach ( example_src IN LISTS example_sources )


### PR DESCRIPTION
This PR removes the  `add_test()` call in `make_exe` step for examples only. 

This allows the examples to be built, but not run during `make test` and should prevent the interactive demos from causing issues with CI.
I have tested this locally on my machine with no issues and 23 tests (previously 30) passing.